### PR TITLE
Add run_exports

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -18,7 +18,7 @@ source:
     - disable_macos_framework.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -38,6 +38,8 @@ requirements:
         - xorg-xorgproto
   run_constraints:
     - libvulkan-headers =${{ version }}
+  run_exports:
+    - ${{ pin_subpackage(name, upper_bound="x") }}
   ignore_run_exports:
     from_package: 
        # only the headers are used by the feedstock


### PR DESCRIPTION
I am not sure how we never realized this, but if a recipe as a `host` dependency on `libvulkan-loader`, I think it make sense that we have a run dependency on it, see for example https://github.com/conda-forge/llama.cpp-feedstock/pull/64 .

fyi @hmaarrfk @JarrettSJohnson, comments are welcome.


Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
